### PR TITLE
Add WithBearerAuth

### DIFF
--- a/tester.go
+++ b/tester.go
@@ -107,15 +107,20 @@ func (tt *Tester) HasHeaders(headers map[string]string) *Tester {
 	return tt
 }
 
-// BasicAuth ///////////////////////////////////////////////////////
+// authorization headers ///////////////////////////////////////////////////////
 
-// WithBasicAuth aliases for the basic auth request header.
+// WithBasicAuth is an alias to set basic auth in the request header.
 func (tt *Tester) WithBasicAuth(user, pass string) *Tester {
 	var b bytes.Buffer
 	b.WriteString(user)
 	b.WriteString(":")
 	b.WriteString(pass)
 	return tt.WithHeader("Authorization", "Basic "+base64.StdEncoding.EncodeToString(b.Bytes()))
+}
+
+// WithBearerAuth is an alias to set bearer auth in the request header.
+func (tt *Tester) WithBearerAuth(token string) *Tester {
+	return tt.WithHeader("Authorization", "Bearer: "+token)
 }
 
 // cookies ///////////////////////////////////////////////////////

--- a/tester_test.go
+++ b/tester_test.go
@@ -160,6 +160,15 @@ func TestWithBasicAuth(t *testing.T) {
 	assert.Equal(t, checker.request.Header.Get("Authorization"), "Basic "+h)
 }
 
+func TestWithBearerAuth(t *testing.T) {
+	checker := makeTestChecker()
+	checker.Test(t, "GET", "/some").
+		WithBearerAuth("token")
+
+	v := checker.request.Header.Get("Authorization")
+	assert.Equal(t, "Bearer: token", v)
+}
+
 func TestWithCookie(t *testing.T) {
 	checker := makeTestChecker()
 	checker.Test(t, "GET", "/some").


### PR DESCRIPTION
```
// WithBearerAuth is an alias to set bearer auth in the request header.
func (tt *Tester) WithBearerAuth(token string) *Tester {
	return tt.WithHeader("Authorization", "Bearer: "+token)
}
```