### PR TITLE
fix: Correct Bearer token format in Authorization header

### DIFF
--- a/tester_auth.go
+++ b/tester_auth.go
@@ -18,5 +18,5 @@ func (tt *Tester) WithBasicAuth(user, pass string) *Tester {
 
 // WithBearerAuth is an alias to set bearer auth in the request header.
 func (tt *Tester) WithBearerAuth(token string) *Tester {
-	return tt.WithHeader("Authorization", "Bearer: "+token)
+	return tt.WithHeader("Authorization", "Bearer "+token)
 }

--- a/tester_auth_test.go
+++ b/tester_auth_test.go
@@ -27,5 +27,5 @@ func TestTester_WithBearerAuth(t *testing.T) {
 		WithBearerAuth("token")
 
 	v := checker.request.Header.Get("Authorization")
-	assert.Equal(t, "Bearer: token", v)
+	assert.Equal(t, "Bearer token", v)
 }


### PR DESCRIPTION
Change "Bearer: token" to "Bearer token" to comply with RFC 6750. The previous format incorrectly included a colon after "Bearer".